### PR TITLE
Fix for test/unit/sql/data-types.test.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sequelize
 
-[![Build Status](https://travis-ci.org/hariprasadkulkarni/sequelize.svg?branch=master)](https://travis-ci.org/hariprasadkulkarni/sequelize) [![Dependency Status](https://david-dm.org/sequelize/sequelize.svg)](https://david-dm.org/sequelize/sequelize) [![Test Coverage](https://codeclimate.com/github/sequelize/sequelize/badges/coverage.svg)](https://codeclimate.com/github/sequelize/sequelize)
+[![Build Status](https://travis-ci.org/sequelize/sequelize.svg?branch=master)](https://travis-ci.org/sequelize/sequelize) [![Dependency Status](https://david-dm.org/sequelize/sequelize.svg)](https://david-dm.org/sequelize/sequelize) [![Test Coverage](https://codeclimate.com/github/sequelize/sequelize/badges/coverage.svg)](https://codeclimate.com/github/sequelize/sequelize)
 [![Bountysource](https://www.bountysource.com/badge/team?team_id=955&style=bounties_received)](https://www.bountysource.com/teams/sequelize/issues?utm_source=Sequelize&utm_medium=shield&utm_campaign=bounties_received)
 [![Slack Status](http://sequelize-slack.herokuapp.com/badge.svg)](http://sequelize-slack.herokuapp.com)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sequelize
 
-[![Build Status](https://travis-ci.org/sequelize/sequelize.svg?branch=master)](https://travis-ci.org/sequelize/sequelize) [![Dependency Status](https://david-dm.org/sequelize/sequelize.svg)](https://david-dm.org/sequelize/sequelize) [![Test Coverage](https://codeclimate.com/github/sequelize/sequelize/badges/coverage.svg)](https://codeclimate.com/github/sequelize/sequelize)
+[![Build Status](https://travis-ci.org/hariprasadkulkarni/sequelize.svg?branch=master)](https://travis-ci.org/sequelize/sequelize) [![Dependency Status](https://david-dm.org/sequelize/sequelize.svg)](https://david-dm.org/sequelize/sequelize) [![Test Coverage](https://codeclimate.com/github/sequelize/sequelize/badges/coverage.svg)](https://codeclimate.com/github/sequelize/sequelize)
 [![Bountysource](https://www.bountysource.com/badge/team?team_id=955&style=bounties_received)](https://www.bountysource.com/teams/sequelize/issues?utm_source=Sequelize&utm_medium=shield&utm_campaign=bounties_received)
 [![Slack Status](http://sequelize-slack.herokuapp.com/badge.svg)](http://sequelize-slack.herokuapp.com)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sequelize
 
-[![Build Status](https://travis-ci.org/hariprasadkulkarni/sequelize.svg?branch=master)](https://travis-ci.org/sequelize/sequelize) [![Dependency Status](https://david-dm.org/sequelize/sequelize.svg)](https://david-dm.org/sequelize/sequelize) [![Test Coverage](https://codeclimate.com/github/sequelize/sequelize/badges/coverage.svg)](https://codeclimate.com/github/sequelize/sequelize)
+[![Build Status](https://travis-ci.org/hariprasadkulkarni/sequelize.svg?branch=master)](https://travis-ci.org/hariprasadkulkarni/sequelize) [![Dependency Status](https://david-dm.org/sequelize/sequelize.svg)](https://david-dm.org/sequelize/sequelize) [![Test Coverage](https://codeclimate.com/github/sequelize/sequelize/badges/coverage.svg)](https://codeclimate.com/github/sequelize/sequelize)
 [![Bountysource](https://www.bountysource.com/badge/team?team_id=955&style=bounties_received)](https://www.bountysource.com/teams/sequelize/issues?utm_source=Sequelize&utm_medium=shield&utm_campaign=bounties_received)
 [![Slack Status](http://sequelize-slack.herokuapp.com/badge.svg)](http://sequelize-slack.herokuapp.com)
 

--- a/lib/dialects/oracle/data-types.js
+++ b/lib/dialects/oracle/data-types.js
@@ -6,6 +6,8 @@ var BaseTypes = require('../../data-types')
 
 BaseTypes.ABSTRACT.prototype.dialectTypes = 'http://docs.oracle.com/cd/B28359_01/server.111/b28318/datatype.htm';
 
+var warn = BaseTypes.ABSTRACT.warn.bind(undefined, 'http://docs.oracle.com/cd/B28359_01/server.111/b28318/datatype.htm');
+
 var UUID = function() {
   if (!(this instanceof UUID)) return new UUID();
   BaseTypes.UUID.apply(this, arguments);
@@ -53,10 +55,12 @@ BaseTypes.TEXT.prototype.toSql = function() {
   // Using unicode is just future proof
   if (this._length) {
     if (this._length.toLowerCase() === 'tiny') { // tiny = 2^8
-      this.warn('Oracle does not support TEXT with the `length` = `tiny` option. `NVARCHAR2(256)` will be used instead.');
+      warn('Oracle does not support TEXT with the `length` = `tiny` option. `NVARCHAR2(256)` will be used instead.');
+      //this.warn('Oracle does not support TEXT with the `length` = `tiny` option. `NVARCHAR2(256)` will be used instead.');
       return 'NVARCHAR2(256)';
     }
-    this.warn('Oracle does not support TEXT with the `length` option. `CLOB` will be used instead.');
+    warn('Oracle does not support TEXT with the `length` option. `CLOB` will be used instead.');
+    //this.warn('Oracle does not support TEXT with the `length` option. `CLOB` will be used instead.');
   }
   return 'CLOB';
 };


### PR DESCRIPTION
The data-types.test.js reports a type error for absence of `warn` function.

`TypeError: Object object has no method 'warn'`

Added the definition for the warn function based on the definition in other [dialects](https://github.com/sequelize/sequelize/blob/master/lib/dialects/mssql/data-types.js#L6).
